### PR TITLE
Feature/autosnap upgrade

### DIFF
--- a/autosnap/Chart.yaml
+++ b/autosnap/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for deploying autosnap, periodic google cloud disk snapshots
 name: autosnap
-version: 0.0.1
+version: 0.0.4
 appVersion: 0.0.4

--- a/autosnap/Chart.yaml
+++ b/autosnap/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
-description: A Helm chart for deploying autonsnap, periodic google cloud disk snapshots
+description: A Helm chart for deploying autosnap, periodic google cloud disk snapshots
 name: autosnap
-version: 0.0.3
+version: 0.0.1
+appVersion: 0.0.4

--- a/autosnap/templates/deployment.yaml
+++ b/autosnap/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: autosnap-backup
@@ -8,11 +8,18 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: autosnap
   template:
     metadata:
       labels:
-        app: backup
+        app: autosnap
     spec:
+      volumes:
+        - name: google-application-credentials
+          secret:
+            secretName: autosnap-credentials
       containers:
         - name: backup
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -27,6 +34,11 @@ spec:
               value: {{ .Values.snapshotName }}
             - name: INTERVAL_MINUTES
               value: "{{ .Values.interval }}"
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/key.json"
           command: ['/bin/bash','-c','python app.py']
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: google-application-credentials
+              mountPath: "/var/secrets/google"


### PR DESCRIPTION
Autosnap upgrade. 

Since the service account addition on our node pools we need Google Application Credentials for AutoSnap.

Also bumped the chart version and  appVersion made some changes to the manifest.

- [x] Tested with rehive-core-ha-staging
- [ ] Test with the bitcoin-hooks backups
- [ ] Test with the stellar-hooks backups 
- [ ] Test with the geth backups if necessary