### PR TITLE
Add nodeSelector and tolerations support to rehive-service (1.1.4)

### DIFF
--- a/rehive-service/CHANGELOG.md
+++ b/rehive-service/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file documents all notable changes to Rehive Service Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.1.4 - 2026-06-11
+### Added
+- Added optional `deployment.nodeSelector` and `deployment.tolerations` values to the main deployment.
+- Added optional per-worker `nodeSelector` and `tolerations` values to worker deployments.
+
 ## v1.1.3 - 2024-05-10
 ### Added
 - Added default lifecycle hook to the Helm chart to prevent 503 during deployment.

--- a/rehive-service/Chart.yaml
+++ b/rehive-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes for Rehive Services
 name: rehive-service
-version: 1.1.3
+version: 1.1.4
 maintainers:
 - name: Rehive
   email: info@rehive.com

--- a/rehive-service/templates/deployment.yaml
+++ b/rehive-service/templates/deployment.yaml
@@ -24,6 +24,14 @@ spec:
     spec:
       serviceAccountName: {{ include "rehive-service.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: webapp
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/rehive-service/templates/workers.yaml
+++ b/rehive-service/templates/workers.yaml
@@ -38,6 +38,14 @@ spec:
       annotations:
         helm/revision: "{{ $revision }}" # Hack to force restart on upgrade
     spec:
+      {{- with $worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ $worker.name }}
         image: {{ $repository }}:{{ $tag }}


### PR DESCRIPTION
## Summary
- Adds optional `deployment.nodeSelector` and `deployment.tolerations` values to the main deployment template
- Adds optional per-worker `nodeSelector` and `tolerations` to worker deployments
- Bumps chart version to 1.1.4 and updates the changelog

## Motivation
Lets a service pin its web pods to a dedicated (tainted) node pool — first use case is rehive-core's new `c4d-standard-4` pool (`dedicated=web:NoSchedule`) for latency-critical request handling, while celery workers stay on the existing pool.

## Backward compatibility
Both blocks are wrapped in `{{- with }}`, so charts deployed with existing values files render byte-identical output. Verified with `helm template` against rehive-core production values: with the new keys absent, no `nodeSelector`/`tolerations` are emitted across all 15 deployments; with them set, only the web deployment carries the toleration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)