### PR TITLE
rehive-service 2.0.0: unique per-worker Deployment selectors (requires migration)

### DIFF
--- a/rehive-service/CHANGELOG.md
+++ b/rehive-service/CHANGELOG.md
@@ -3,6 +3,19 @@
 This file documents all notable changes to Rehive Service Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v2.0.0 - 2026-07-10
+
+### Changed
+- **Breaking:** every worker Deployment's selector now includes a unique `rehive.io/worker: <worker name>` label. Previously all workers in a release shared an identical selector (`app.kubernetes.io/name` + `app.kubernetes.io/component: worker`), which violates the Kubernetes requirement that controller selectors not overlap and made it impossible to target a single worker with a Service, PDB, or HPA.
+
+### Upgrading from 1.x
+Selectors are immutable, so each existing worker Deployment must be deleted and recreated once. `helm upgrade` alone will fail with a field-immutability error. Two options per worker:
+
+- **Zero consumer downtime** (recommended for busy queues): `kubectl delete deployment <worker> --cascade=orphan`, run `helm upgrade`, wait for the new pods to become Ready, then delete the orphaned old ReplicaSet **by name** (never by label — old and new share labels).
+- **Simple, brief consumption gap** (fine for low-traffic queues and required for beat schedulers, where overlap would duplicate scheduled tasks): `kubectl delete deployment <worker>`, then `helm upgrade`. Tasks queue in the broker during the gap; nothing is lost.
+
+The web Deployment, Service, and PDB are untouched — web traffic is unaffected throughout.
+
 ## v1.3.0 - 2026-07-10
 
 ### Added

--- a/rehive-service/Chart.yaml
+++ b/rehive-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: A Helm chart for Kubernetes for Rehive Services
 name: rehive-service
-version: 1.3.0
+version: 2.0.0
 maintainers:
 - name: Rehive
   email: info@rehive.com

--- a/rehive-service/README.md
+++ b/rehive-service/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the rehive-service char
 | `workers.deployments[].nodeSelector` | Optional per-worker node labels for scheduling | `{}` |
 | `workers.deployments[].tolerations` | Optional per-worker tolerations | `[]` |
 | `workers.deployments[].strategy` | Optional per-worker rollout strategy. Set `{type: Recreate}` for singletons like celery beat schedulers so two copies never run concurrently. | RollingUpdate, `maxUnavailable: 0`, `maxSurge: 2` |
+| `workers.deployments[].name` | Worker deployment name; also set as the `rehive.io/worker` label in the worker's (immutable) selector, so pods of a single worker can be targeted with `-l rehive.io/worker=<name>` | |
 | `image.repository` | Docker image containing the service's source | `rehive/example` |
 | `image.tag` | Docker image tag to use for the deployment. This is usually set to a version. | `latest` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/rehive-service/templates/workers.yaml
+++ b/rehive-service/templates/workers.yaml
@@ -23,12 +23,14 @@ metadata:
     {{ $labels | nindent 4 }}
     app.kubernetes.io/name: {{ $serviceName }}
     app.kubernetes.io/component: worker
+    rehive.io/worker: {{ $worker.name }}
 spec:
   replicas: {{ $worker.replicaCount }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ $serviceName }}
       app.kubernetes.io/component: worker
+      rehive.io/worker: {{ $worker.name }}
   strategy:
     {{- if $worker.strategy }}
     {{- toYaml $worker.strategy | nindent 4 }}
@@ -43,6 +45,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ $serviceName }}
         app.kubernetes.io/component: worker
+        rehive.io/worker: {{ $worker.name }}
       annotations:
         helm/revision: "{{ $revision }}" # Hack to force restart on upgrade
     spec:


### PR DESCRIPTION
Part 2 of the chart audit, stacked on #27 (retarget to `master` after #27 merges).

## What changes

Every worker Deployment's selector, pod template, and metadata gain a unique `rehive.io/worker: <worker name>` label. Today all workers in a release share an identical selector (`app.kubernetes.io/name` + `app.kubernetes.io/component: worker`) — rehive-core production runs 14 Deployments whose selectors all match each other's pods. Kubernetes requires controller selectors not to overlap, and the shared selector makes it impossible to target one worker with a Service, PDB, or HPA. `app.kubernetes.io/component: worker` is kept, so "all workers" selection (used e.g. in NOTES.txt) still works.

**Chart version 2.0.0** because upgrading existing releases needs a one-time manual step.

## Migration runbook (per release)

Selectors are immutable — a plain `helm upgrade` from 1.x will fail with a field-immutability error on every worker Deployment. The web Deployment, Service, PDB, and Ingress are untouched: **web traffic is unaffected throughout**. Roll staging first, then production; workers can be migrated one at a time or in batches (each is independent).

### Busy queues — zero consumer downtime (e.g. worker-webhooks)

```bash
# 1. Remove the Deployment object; its pods keep running and consuming
kubectl delete deployment worker-webhooks --cascade=orphan -n <ns>

# 2. Upgrade — Helm recreates the Deployment with the new selector,
#    new pods start alongside the orphaned old ones (double consumers, same as a normal rollout)
helm upgrade <release> rehive/rehive-service --version 2.0.0 -f values.yaml -n <ns>

# 3. Once new pods are Ready, delete the orphaned old ReplicaSet.
#    Identify it by name/ownerReference — it's the one with no owner.
#    NEVER delete by label: old and new ReplicaSets share labels.
kubectl get rs -n <ns>          # spot the orphan (no OWNER, old age)
kubectl delete rs worker-webhooks-<oldhash> -n <ns>
```

Old pods receive a graceful TERM at step 3 and finish in-flight tasks within `terminationGracePeriodSeconds` (celery warm shutdown).

### Low-traffic queues and the beat scheduler — simple, brief gap

```bash
kubectl delete deployment <worker> -n <ns>
helm upgrade <release> rehive/rehive-service --version 2.0.0 -f values.yaml -n <ns>
```

Consumption pauses until the new pods are Ready; tasks queue in RabbitMQ, nothing is lost. For the **beat scheduler this is the required path** — orphaning would run two beats concurrently and emit duplicate scheduled tasks. (Once on 2.0.0, also set `strategy: {type: Recreate}` on the scheduler — see #27.)

### If you delete all workers up front

A single `kubectl delete deployment -n <ns> -l app.kubernetes.io/component=worker` followed by one `helm upgrade` also works (label-delete is safe *here* because no new-style Deployments exist yet) — at the cost of all queues pausing for one rollout. Simplest option for staging.

## Verification
- `helm lint` clean with default and rehive-core production values.
- Rendered against rehive-core production values: all 15 Deployment selectors now unique (was 2 unique across 15); diff vs #27 contains only the new `rehive.io/worker` labels and the chart version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)